### PR TITLE
Configure Poetry for Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,89 @@
-FROM mcr.microsoft.com/devcontainers/universal:2-linux
+FROM mcr.microsoft.com/devcontainers/python:3.11 as builder
 
-# TODO: There was
-RUN apt-get update && apt install -y --no-install-recommends \
+RUN apt update && sudo apt install -y --no-install-recommends \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
+    libsqlite3-dev
+
+
+# ==============================================================================
+# Parallel Build Intermediate Layers
+# ==============================================================================
+FROM builder as py38
+
+WORKDIR ${HOME}/build
+
+RUN wget https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz && \
+    tar xvf Python-3.8.19.tgz && \
+    ./Python-3.8.19/configure --enable-optimizations && \
+    make altinstall
+
+
+FROM builder as py39
+
+WORKDIR ${HOME}/build
+
+RUN wget https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz && \
+    tar xvf Python-3.9.19.tgz && \
+    ./Python-3.9.19/configure --enable-optimizations && \
+    make altinstall
+
+
+FROM builder as py310
+
+WORKDIR ${HOME}/build
+
+RUN wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar xvf Python-3.10.14.tgz && \
+    ./Python-3.10.14/configure --enable-optimizations && \
+    make altinstall
+
+
+FROM builder as py312
+
+WORKDIR ${HOME}/build
+
+RUN wget https://www.python.org/ftp/python/3.12.4/Python-3.12.4.tgz && \
+    tar xvf Python-3.12.4.tgz && \
+    ./Python-3.12.4/configure --enable-optimizations && \
+    make altinstall
+
+
+# ==============================================================================
+# Dev Container
+# ==============================================================================
+FROM mcr.microsoft.com/devcontainers/python:3.11 as dev
+
+COPY --from=py38 /usr/local/include/python3.8/ /usr/local/include/python3.8/
+COPY --from=py38 /usr/local/bin/python3.8 /usr/local/bin/
+COPY --from=py38 /usr/local/bin/python3.8-config /usr/local/bin/
+COPY --from=py38 /usr/local/share/man/man1/python3.8.1 /usr/local/share/man/man1/
+COPY --from=py38 /usr/local/lib/python3.8/ /usr/local/lib/python3.8/
+COPY --from=py38 /usr/local/lib/libpython3.8.a /usr/local/lib/
+
+COPY --from=py310 /usr/local/include/python3.9/ /usr/local/include/python3.9/
+COPY --from=py310 /usr/local/bin/python3.9 /usr/local/bin/
+COPY --from=py310 /usr/local/bin/python3.9-config /usr/local/bin/
+COPY --from=py310 /usr/local/share/man/man1/python3.9.1 /usr/local/share/man/man1/
+COPY --from=py310 /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+COPY --from=py310 /usr/local/lib/libpython3.9.a /usr/local/lib/
+
+COPY --from=py312 /usr/local/include/python3.12/ /usr/local/include/python3.12/
+COPY --from=py312 /usr/local/bin/python3.12 /usr/local/bin/python3.12
+COPY --from=py312 /usr/local/bin/python3.12-config /usr/local/bin/python3.12-config
+COPY --from=py312 /usr/local/share/man/man1/python3.12.1 /usr/local/share/man/man1/python3.12.1
+COPY --from=py312 /usr/local/lib/python3.12/ /usr/local/lib/python3.12/
+COPY --from=py312 /usr/local/lib/libpython3.12.a /usr/local/lib/libpython3.12.a
+
+
+RUN apt update && apt install -y --no-install-recommends \
     httpie \
     silversearcher-ag
+
+RUN pipx install poetry && pipx ensurepath

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,12 +67,19 @@ COPY --from=py38 /usr/local/share/man/man1/python3.8.1 /usr/local/share/man/man1
 COPY --from=py38 /usr/local/lib/python3.8/ /usr/local/lib/python3.8/
 COPY --from=py38 /usr/local/lib/libpython3.8.a /usr/local/lib/
 
-COPY --from=py310 /usr/local/include/python3.9/ /usr/local/include/python3.9/
-COPY --from=py310 /usr/local/bin/python3.9 /usr/local/bin/
-COPY --from=py310 /usr/local/bin/python3.9-config /usr/local/bin/
-COPY --from=py310 /usr/local/share/man/man1/python3.9.1 /usr/local/share/man/man1/
-COPY --from=py310 /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
-COPY --from=py310 /usr/local/lib/libpython3.9.a /usr/local/lib/
+COPY --from=py39 /usr/local/include/python3.9/ /usr/local/include/python3.9/
+COPY --from=py39 /usr/local/bin/python3.9 /usr/local/bin/
+COPY --from=py39 /usr/local/bin/python3.9-config /usr/local/bin/
+COPY --from=py39 /usr/local/share/man/man1/python3.9.1 /usr/local/share/man/man1/
+COPY --from=py39 /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+COPY --from=py39 /usr/local/lib/libpython3.9.a /usr/local/lib/
+
+COPY --from=py310 /usr/local/include/python3.10/ /usr/local/include/python3.10/
+COPY --from=py310 /usr/local/bin/python3.10 /usr/local/bin/
+COPY --from=py310 /usr/local/bin/python3.10-config /usr/local/bin/
+COPY --from=py310 /usr/local/share/man/man1/python3.10.1 /usr/local/share/man/man1/
+COPY --from=py310 /usr/local/lib/python3.10/ /usr/local/lib/python3.10/
+COPY --from=py310 /usr/local/lib/libpython3.10.a /usr/local/lib/
 
 COPY --from=py312 /usr/local/include/python3.12/ /usr/local/include/python3.12/
 COPY --from=py312 /usr/local/bin/python3.12 /usr/local/bin/python3.12

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,31 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+// ===================================================================================================
+// For format details, see:
+//   https://aka.ms/devcontainer.json
+//   https://containers.dev/implementors/json_reference/
+//
+// For config options see the README at:
+//   https://github.com/devcontainers/templates/tree/main/src/universal
+// ===================================================================================================
 {
-	// "name": "Default Linux Universal",
-	"name": "Custom Default Linux Universal",
+	"name": "Python Debian Codespaces Devcontainer",
 
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	//"image": "mcr.microsoft.com/devcontainers/universal:2-linux"
+
+	// ===================================================================================================
+	// Use a prebuilt image or build a custom image with a Dockerfile or Docker Compose file. More info:
+	//   https://containers.dev/guide/dockerfile
+	//   https://containers.dev/implementors/json_reference/#image-specific
+	// ===================================================================================================
+	// "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+
+
+	// ===================================================================================================
+	// VSCode specific properties go under `vscode` inside `customizations`.  For docs on that and other
+	// supporting tools and services:
+	//   https://containers.dev/supporting
+	// ===================================================================================================
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -17,6 +34,10 @@
 				"ms-python.python"
 			],
 			"settings": {
+				// ===================================================================================================
+				// Install your dotfiles into the container.
+				//   https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories
+				// ===================================================================================================
 				"dotfiles.repository": "GuyHoozdis/dotfiles",
 				"dotfiles.targetPath": "~/dotfiles",
 				"dotfiles.installCommand": "./share/install/vscode/install.sh"
@@ -24,20 +45,47 @@
 		}
 	},
 
+
+	// ===================================================================================================
 	// Features to add to the dev container. More info: https://containers.dev/features.
+	// ===================================================================================================
 	// "features": {},
 
+
+	// ===================================================================================================
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// ===================================================================================================
 	// "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+
+	// ===================================================================================================
+	// Use 'postCreateCommand' to run commands after the container is created.  See the docs
+	// on Lifecycle Scripts for other commands available:
+	//   https://containers.dev/implementors/json_reference/#lifecycle-scripts
+	// ---------------------------------------------------------------------------------------------------
+	// Examples:
+	//
 	// "postCreateCommand": "git config --global --add safe.directory /workspace/devcontainer-experiment"
-	"postCreateCommand": ["bash", "-c", "./.devcontainer/postCreateCommand.sh"]
+	//
+	// "postCreateCommand": ["bash", "-c", "./.devcontainer/postCreateCommand.sh"]
+	//
+	// "postCreateCommand": [
+	// 	 "bash", "-c", "./.devcontainer/postCreateCommand.sh $*",
+	// 	 "<ignored>",
+	// 	 "${containerWorkspaceFolder}"
+	// ]
+	// ---------------------------------------------------------------------------------------------------
+	// The postCreateCommand.sh script is left for reference.  It isn't doing anything right now.
+	// ===================================================================================================
+	"postCreateCommand": {
+		"script": ["bash", "-c", "./.devcontainer/postCreateCommand.sh"],
+		"safeDir": ["git", "config", "--global", "--add", "safe.directory", "${containerWorkspaceFolder}"]
+	}
 
-	// Configure tool-specific properties.
-	// "customizations": {},
 
+	// ===================================================================================================
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// !!!: Don't do this!
+	// ===================================================================================================
 	// "remoteUser": "root"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -20,7 +20,39 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 END='\033[0m'
 
-echo -e "[${GREEN}*${END}] ${RED}All your postCreateCommand are belong to us${END}!"
 
-# ???: Why does the container need this sometimes, but not others?
-# git config --global --add safe.directory /workspaces/devcontainer-experiment
+echo -e "${GREEN}== ${RED}PostCreateCommand${GREEN} ==${END}"
+env | sort
+echo -e "${GREEN}================================================================================${END}"
+
+# ==============================================================================
+# Debugging passing variables into the script from the devcontainer.json
+#
+# From a terminal:
+#  $ bash -c '.devcontainer/postCreateCommand.sh $@' scriptname one two three
+#
+# From the devcontainer.json:
+# "postCreateCommand": [
+#   "bash", "-c", "./.devcontainer/postCreateCommand.sh $*",
+#   "<ignored>",
+#   "${localWorkspaceFolder}"
+#   "${containerWorkspaceFolder}"
+#   "${localWorkspaceFolderBasename}"
+#   "${containerWorkspaceFolderBasename}"
+# ]
+# ------------------------------------------------------------------------------
+# Both of the above examples work with the logic below.  For more info about how
+# arguments are passed and parsed from the devcontainer.json commands, see:
+#   https://containers.dev/implementors/json_reference/#formatting-string-vs-array-properties
+#
+# In the postCreateCommand example above using $* vs. "$*", $@, or "$@" have
+# differet behaviors.  Notice the terminal command example uses single qotes
+# around the script and the postCreateCommand does not.
+# ==============================================================================
+echo -e "nArgs: $#"
+echo -e "localWorkspaceFolder = ${1-<Missing>}"
+echo -e "containerWorkspaceFolder = ${2-<Missing>}"
+echo -e "localWorkspaceFolderBasename = ${3-<Missing>}"
+echo -e "containerWorkspaceFolderBasename = ${4-<Missing>}"
+
+echo -e "[${GREEN}*${END}] ${RED}All your postCreateCommand are belong to us${END}!"

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,29 @@
+# Debian
+https://aruljohn.com/blog/install-python-debian/
+
+```
+# If these packages aren't installed, they will be needed.
+$ sudo apt update
+$ sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
+    libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev
+
+# Down load the version you want to install.
+$ wget https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz
+$ tar -xzvf Python-3.12.2.tgz
+$ cd Python-3.12.2/
+
+# Configure and use altinstall so you don't overwrite the symlinks to the existing installed version
+$ ./configure --enable-optimizations
+$ sudo make altinstall
+```
+
+# Ubuntu
+https://askubuntu.com/questions/1398568/installing-python-who-is-deadsnakes-and-why-should-i-trust-them
+
+
+# Optimizations 
+https://luis-sena.medium.com/creating-the-perfect-python-dockerfile-51bdec41f1c8
+
+
+# Best Practices
+https://testdriven.io/blog/docker-best-practices/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Especially on Windows OS, at least for now, it slows down performance.  Perhaps due to filesystem communication across
 the system boundary from the native environment over to the WSL which is the environment that the container lives in.
 
+See the
 
 ## Clone in Container Volume
 
@@ -14,7 +15,7 @@ Take a GitHub repo that already exists and clone it into the container.
 1. Open the command palette and select: _Dev Containers: Clone Repository in Container Volume_ ([docs][clone-in-container]).
 1. You will be prompted for the repo URL (if not logged into GitHub it will prompt you for credentials and authorization).
 1. VS Code will start building the container.  Click the "Show Log" link in the dialog window in the bottom right of VS Code window.
-1. You will be prompted to _Select a container configuration template_.  Search by name, scroll to pick, or click _Show All Definitions_ to see more options.  Select the _Default Linux Universal_ image - unless you have a specific need.  This is the image used for Codespaces.  See the [docs]][default-linux-universal] for details about what the image contains (it's a lot).  One downside to selecting this image is that it is large and will take a while to download.
+1. You will be prompted to _Select a container configuration template_.  Search by name, scroll to pick, or click _Show All Definitions_ to see more options.  Select the _Default Linux Universal_ image - unless you have a specific need.  This is the image used for Codespaces.  See the [docs][default-linux-universal] for details about what the image contains (it's a lot).  One downside to selecting this image is that it is large and will take a while to download.
 1. You will be prompted to _Select additional features to install_.  Leave this as `0 Selected` and click `OK`. (Note: Features can be added later through the _Configure Container Features_ command.)
 1. Take a break while waiting for the image to be built.
 1. Open a new terminal and you should be in `/workspaces/<repo-name>` directory.  `whoami` should return `codespaces`.  `git status` will show the `.devcontainer` and `.github` directories that have been created locally, but not committed to the project yet.
@@ -49,6 +50,7 @@ Open `devcontainer.json`.  Use value for "image" in the `Dockerfile`, then repla
 
 Open the palette and select _Dev Containers: Rebuild Container_.  Don't forget to add and commit your changed files.
 
+Refer to the [Dev Container Metadata Reference][devcontainer-metadata-reference] for the full file specification and the [pre-defined environment variables][devcontainer-pre-defined-variables] that are available.
 
 ### Locate the Actual Files from the Repo
 
@@ -92,7 +94,27 @@ From the Web GUI, via the command palette or the
 TODO: Explore how this is different than _Clone in Container Volume_ ([docs][clone-in-named-volume])
 
 
-[default-linux-universal]: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/README.md
+# Devcontainer Images
+
+To be an image compatible with VSCode _devcontainers_, the image must meet a certain [specification][devcontainer-spec].
+
+This is the image that is used, by default, in GitHub Codespaces.
+- [Linux Universal Image on GitHub][default-linux-universal]
+- [Linux Universal Image on Microsoft Artifact Registry](https://mcr.microsoft.com/en-us/product/devcontainers/universal/tags)
+- [Linux Universal Image on Docker Hub](https://hub.docker.com/r/microsoft/vscode-devcontainers)
+
+
+## Improve the Performance of Your Container
+
+- [Improve disk performance](https://code.visualstudio.com/remote/advancedcontainers/improve-performance)
+- [Multi-stage builds](https://docs.docker.com/build/guide/multi-stage/)
+
+
+[default-linux-universal]: https://github.com/devcontainers/images/tree/main/src/universal
+[advanced-container-config]: https://code.visualstudio.com/remote/advancedcontainers/overview
+[devcontainer-spec]: https://github.com/devcontainers/spec/blob/main/README.md
+[devcontainer-metadata-reference]: https://containers.dev/implementors/json_reference/
+[devcontainer-pre-defined-variables]: https://containers.dev/implementors/json_reference/#variables-in-devcontainerjson
 [clone-in-container]: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-clone-repository-in-container-volume
 [clone-in-named-volume]: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-targeted-named-volume
 [container-features]: https://containers.dev/features

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+prompt = "[poetry]:{project_name}-py{python_version}"


### PR DESCRIPTION
# Why Are We Doing This

When I tried to use the devcontainer configuration, as it was, as a starting point in a different project it didn't work as expected.  I was getting errors when I ran poetry commands.  These changes help keep the external poetry separate from the one inside the container.

## Always Don't Do What Barry Did

Even though it is in the container, we still want to use a virtualenv for the application and separate environment for `poetry`. 
 When Barry insisted on doing what he did, setting `virtualenvs.create = false`, we ran into the issue described in [this issue][poetry-isolation] and then we did the work around.  That's a lot of non-standard effort to avoid typing `poetry run` inside the container.

In this image, `poetry` is installed via `pipx`.  There are several other tools installed in a similar manner that are already a part of the base image.  Those tools should probably be pinned.  They aren't yet; well, poetry isn't.  IDK about the tools that come with the image.

## All Your Python Are Belong To Us

I dropped the universal image (i.e. "All the things!") that I was initially using and picked one focused on Python.  Still a Codespaces / Devcontainer image.  It comes with 3.11 and then I installed 3.8, 3.9, 3.10, and 3.12.  They build in parallel in a multi-stage build, so it is as fast as it can be.  If that is too much there are still things that can be done to reduce the build time - like use the `COPY --link` command or publish the image or use volume mounts for better disk performance etc.

[poetry-isolation]: https://github.com/python-poetry/poetry/issues/6397#issuecomment-1236327500